### PR TITLE
Ensure Participant#sort_name is set

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -3,4 +3,16 @@ class Participant < ApplicationRecord
 
   belongs_to :import_order, optional: true
   has_many :artist_credit_participants, dependent: :destroy
+
+  validates :name, presence: true
+  validates :sort_name, presence: true
+
+  before_validation :ensure_sort_name_has_a_value
+
+  private
+
+  def ensure_sort_name_has_a_value
+    return if sort_name.present?
+    self.sort_name = name
+  end
 end

--- a/test/models/artist_credit_participant_test.rb
+++ b/test/models/artist_credit_participant_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ArtistCreditParticipantTest < ActiveSupport::TestCase
   test "delegates name to Participant" do
     artist_credit = ArtistCredit.create!(name: "C-List celebrity")
-    participant = Participant.create!(name: "Superstar", sort_name: "Superstar")
+    participant = Participant.create!(name: "Superstar")
 
     artist_credit_participant = ArtistCreditParticipant.new(artist_credit: artist_credit, participant: participant, position: 0)
 

--- a/test/models/artist_credit_test.rb
+++ b/test/models/artist_credit_test.rb
@@ -8,11 +8,11 @@ class ArtistCreditTest < ActiveSupport::TestCase
   test "join names" do
     artist_credit = ArtistCredit.new
 
-    participant = Participant.create!(name: "first", sort_name: "first")
+    participant = Participant.create!(name: "first")
     acp = ArtistCreditParticipant.new(participant: participant, join_phrase: " feat. ", position: 0)
     artist_credit.participants << acp
 
-    participant = Participant.create!(name: "second", sort_name: "second")
+    participant = Participant.create!(name: "second")
     acp = ArtistCreditParticipant.new(participant: participant, join_phrase: " bad ", position: 1)
     artist_credit.participants << acp
 

--- a/test/models/participant_test.rb
+++ b/test/models/participant_test.rb
@@ -6,4 +6,11 @@ class ParticipantTest < ActiveSupport::TestCase
   setup do
     @subject = Participant.new
   end
+
+  test "set #sort_name unless present" do
+    @subject.name = "Rockstar"
+
+    assert_predicate @subject, :valid?
+    assert_equal "Rockstar", @subject.sort_name
+  end
 end

--- a/test/models/participant_test.rb
+++ b/test/models/participant_test.rb
@@ -13,4 +13,13 @@ class ParticipantTest < ActiveSupport::TestCase
     assert_predicate @subject, :valid?
     assert_equal "Rockstar", @subject.sort_name
   end
+
+  test "leave #sort_name untouched when set" do
+    @subject.name = "Some"
+    @subject.sort_name = "One"
+
+    assert_predicate @subject, :valid?
+    assert_equal "Some", @subject.name
+    assert_equal "One", @subject.sort_name
+  end
 end


### PR DESCRIPTION
Added a callback that sets Participant#sort_name to Participant#name when #sort_name is blank.